### PR TITLE
Update alpine to 3.14.1 to fix CVE-2021-36159

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.14
+FROM docker.io/alpine:3.14.1
 
 RUN apk --no-cache add exim tini && \
     mkdir /var/spool/exim && \


### PR DESCRIPTION
Ref:
https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10749
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159