### PR TITLE
alpine: bump 3.14.2 for openssl security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.14.1
+FROM docker.io/alpine:3.14.2
 
 RUN apk --no-cache add exim tini && \
     mkdir /var/spool/exim && \


### PR DESCRIPTION
- CVE-2021-3711
- CVE-2021-3712