### PR TITLE
Fix reading SMTP password from secrets

### DIFF
--- a/exim.conf
+++ b/exim.conf
@@ -893,17 +893,17 @@ LOGIN:
   driver           = plaintext
   public_name      = LOGIN
   # Username is from SMTP_USERNAME env variable.  Password is from SMTP_PASSWORD docker secret file if it exists, or from SMTP_PASSWORD env variable
-  client_send      = ": ${env{SMTP_USERNAME}{$value} fail } : ${if exists{/run/secrets/passwd} {${readfile{/run/secrets/passwd}}} {${env{SMTP_PASSWORD}{$value}fail}} }"
+  client_send      = ": ${env{SMTP_USERNAME}{$value} fail } : ${if exists{/run/secrets/SMTP_PASSWORD} {${readfile{/run/secrets/SMTP_PASSWORD}{}}} {${env{SMTP_PASSWORD}{$value}fail}} }"
   # Only enabled if SMTP_PASSWORD secret file of env variable exists
-  client_condition = ${if or{ {exists{/run/secrets/passwd}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {true} {false}}
+  client_condition = ${if or{ {exists{/run/secrets/SMTP_PASSWORD}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {true} {false}}
 
 PLAIN:
   driver           = plaintext
   public_name      = PLAIN
   # Username is from SMTP_USERNAME env variable.  Password is from SMTP_PASSWORD docker secret file if it exists, or from SMTP_PASSWORD env variable
-  client_send      = "^${env{SMTP_USERNAME}{$value} fail }^${if exists{/run/secrets/passwd} {${readfile{/run/secrets/passwd}}} {${env{SMTP_PASSWORD}{$value}fail}} }"
+  client_send      = "^${env{SMTP_USERNAME}{$value} fail }^${if exists{/run/secrets/SMTP_PASSWORD} {${readfile{/run/secrets/SMTP_PASSWORD}{}}} {${env{SMTP_PASSWORD}{$value}fail}} }"
   # Only enabled if SMTP_PASSWORD secret file of env variable exists
-  client_condition = ${if or{ {exists{/run/secrets/passwd}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {true} {false}}
+  client_condition = ${if or{ {exists{/run/secrets/SMTP_PASSWORD}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {true} {false}}
 
 #NTLM:
 #  driver = spa
@@ -916,10 +916,10 @@ NTLM:
   # Username is from SMTP_USERNAME env variable.
   client_username  = ${env{SMTP_USERNAME}{$value} fail }
   # Password is from SMTP_PASSWORD docker secret file if it exists, or from SMTP_PASSWORD env variable
-  client_password  = ${if exists{/run/secrets/passwd} {${readfile{/run/secrets/passwd}}} {${env{SMTP_PASSWORD}{$value}{}}} }
+  client_password  = ${if exists{/run/secrets/passwd} {${readfile{/run/secrets/SMTP_PASSWORD}{}}} {${env{SMTP_PASSWORD}{$value}{}}} }
   client_domain    = ${env{SMTP_USERDOMAIN}{$value} {} }
   # Only enabled if SMTP_PASSWORD secret file of env variable exists
-  client_condition = ${if or{ {exists{/run/secrets/passwd}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {true} {false}}
+  client_condition = ${if or{ {exists{/run/secrets/SMTP_PASSWORD}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {true} {false}}
 
 ######################################################################
 #                   CONFIGURATION FOR local_scan()                   #


### PR DESCRIPTION
Fixes #17 

- Secret filename did not match with the documentation
- exim reads files with EOL characters by default, this has to be corrected