### PR TITLE
Fix bad protocol option in remote_smtp transport

### DIFF
--- a/exim.conf
+++ b/exim.conf
@@ -751,7 +751,7 @@ begin transports
 
 remote_smtp:
   driver = smtp
-  protocol = ${if eq{${env{SMARTHOST_PROTOCOL}{$value}{}}}{} {smtp}{${env{SMARTHOST_PROTOCOL}{$value}{}}} }
+  protocol = ${if eq{${env{SMARTHOST_PROTOCOL}{$value}{}}}{}{smtp}{${env{SMARTHOST_PROTOCOL}{$value}{}}}}
   message_size_limit = ${if > {$max_received_linelength}{998} {1}{0}}
   # Set to '*' (auth for all smarthosts)  if the SMTP_PASSWORD secret file or env variable exists, otherwise set to '' (no auth)
   hosts_require_auth = ${if or{ {exists{/run/secrets/SMTP_PASSWORD}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {*} {}}


### PR DESCRIPTION
Remove leading whitespace in the `${if}` expression for the protocol setting. Exim includes literal whitespace in the evaluated value, causing 'bad protocol option' at runtime when SMARTHOST_PROTOCOL is unset.