### PR TITLE
Revert SMARTHOST_PROTOCOL feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,25 +52,6 @@ docker run \
        ghcr.io/devture/exim-relay:SOME_TAGGED_RELEASE
 ```
 
-### Smarthost setup with implicit TLS (SMTPS, port 465)
-
-For providers that require implicit TLS instead of STARTTLS ([RFC 8314](https://www.rfc-editor.org/rfc/rfc8314)):
-
-```
-docker run \
-       --user=100:101 \
-       --name smtp \
-       --restart always \
-       -d \
-       -p 25:8025 \
-       -e HOSTNAME=my.host.name \
-       -e SMARTHOST=some.relayhost.name::465 \
-       -e SMARTHOST_PROTOCOL=smtps \
-       -e SMTP_USERNAME=someuser \
-       -e SMTP_PASSWORD=password \
-       ghcr.io/devture/exim-relay:SOME_TAGGED_RELEASE
-```
-
 ### DKIM setup
 
 To sign outgoing email with DKIM
@@ -152,13 +133,6 @@ If the environment variable is set, sender address verification will be disabled
 ###### SMARTHOST
 
 * A relay host to forward all non-local email through
-
-###### SMARTHOST_PROTOCOL
-
-* The protocol to use when connecting to the smarthost
-* Set to `smtps` for implicit TLS (RFC 8314); use together with port 465 in `SMARTHOST`
-* Defaults to `smtp` (STARTTLS)
-* Example: `SMARTHOST_PROTOCOL=smtps` together with `SMARTHOST=smtp.example.com::465`
 
 ###### SMTP_USERNAME
 

--- a/exim.conf
+++ b/exim.conf
@@ -360,7 +360,7 @@ timeout_frozen_after = 7d
 
 # keep_environment = ^LDAP
 # add_environment = PATH=/usr/bin::/bin
-keep_environment = LOCAL_DOMAINS : RELAY_FROM_HOSTS : RELAY_TO_DOMAINS : RELAY_TO_USERS : DISABLE_SENDER_VERIFICATION : SMARTHOST : SMARTHOST_PROTOCOL : SMTP_PASSWORD : SMTP_USERDOMAIN : SMTP_USERNAME : HOSTNAME
+keep_environment = LOCAL_DOMAINS : RELAY_FROM_HOSTS : RELAY_TO_DOMAINS : RELAY_TO_USERS : DISABLE_SENDER_VERIFICATION : SMARTHOST : SMTP_PASSWORD : SMTP_USERDOMAIN : SMTP_USERNAME : HOSTNAME
 
 
 ######################################################################
@@ -751,7 +751,6 @@ begin transports
 
 remote_smtp:
   driver = smtp
-  protocol = ${if eq{${env{SMARTHOST_PROTOCOL}{$value}{}}}{}{smtp}{${env{SMARTHOST_PROTOCOL}{$value}{}}}}
   message_size_limit = ${if > {$max_received_linelength}{998} {1}{0}}
   # Set to '*' (auth for all smarthosts)  if the SMTP_PASSWORD secret file or env variable exists, otherwise set to '' (no auth)
   hosts_require_auth = ${if or{ {exists{/run/secrets/SMTP_PASSWORD}} {!eq{${env{SMTP_PASSWORD}{$value}{}}}{}} } {*} {}}


### PR DESCRIPTION
Commit 8663931 added a `SMARTHOST_PROTOCOL` environment variable to enable SMTPS (implicit TLS, port 465) by setting the protocol option in Exim's `remote_smtp` transport dynamically via string expansion:

```
protocol = ${if eq{...}{smtp}{...}}
```

However, Exim's `protocol` option in the smtp transport driver does not support string expansion. The expression is passed literally to the protocol parser and causes a `bad protocol option` error at runtime. 

Reverts commits 8663931 and eabef63
- Remove SMARTHOST_PROTOCOL environment variable
- Remove protocol option from remote_smtp transport
- Remove SMARTHOST_PROTOCOL from keep_environment
- Remove SMTPS documentation from README